### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/client/src/components/Profile.tsx
+++ b/client/src/components/Profile.tsx
@@ -48,7 +48,8 @@ const Profile = () => {
   };
 
   const updateProfile = async (id: number, profileData: ProfileData) => {
-    console.log(userId, profileData);
+    const { password, ...nonSensitiveProfileData } = profileData;
+    console.log(userId, nonSensitiveProfileData);
     try {
       const response = await fetch(`/profile/update/${id}`, {
         method: "PATCH",


### PR DESCRIPTION
Potential fix for [https://github.com/Raff29/NTP/security/code-scanning/1](https://github.com/Raff29/NTP/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. The best way to fix this without changing existing functionality is to remove the logging of the `profileData` object or to log only non-sensitive parts of the object. Specifically, we should avoid logging the `password` field.

We will modify the `updateProfile` function to exclude the `password` field from the log statement on line 51. We can achieve this by creating a new object that contains only the non-sensitive fields and logging that object instead.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
